### PR TITLE
AB2D-6110 TIBQ: ab2d-sample-client-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ If you want to:
 3. Save all results for this job to the directory /opt/foo
 4. Filter for claims data updated after March 1, 2020 at 3:00 PM Eastern Time by running the following command:
 
-Then run the following command: 
 `python job-cli.py -prod --auth auth-credentials.base64 --directory /opt/foo --since 2020-03-01T15:00:00.000-05:00`
 
 ### Until Parameter

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Arguments:
   --only_start    -- if you only want to start a job
   --only_monitor  -- if you only want to monitor an already started a job
   --only_download -- if you only want to download an already finished job
-  --since         -- if you only want to pull claims data added after a certain date.
+  --since         -- if you only want to pull claims data updated or filed after a certain date.
                      The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ.
                      Example March 1, 2020 at 3 PM EST -> 2020-03-01T15:00:00.000-05:00. More below.
-  --until         -- if you only want to pull claims data added before a certain date.
+  --until         -- if you only want to pull claims data updated or filed before a certain date.
                      The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ.
                      Example March 1, 2024 at 3 PM EST -> 2024-03-01T15:00:00.000-05:00. More below.
   --fhir          -- FHIR version
@@ -89,11 +89,12 @@ Examples:
 
 If you want to:
 1. Start a job running against production
-1. Using base64 encoded credentials stored in `auth-credentials.base64`
-1. And save all results for this job to the directory /opt/foo
+2. Use base64 encoded credentials stored in `auth-credentials.base64`
+3. Save all results for this job to the directory /opt/foo
+4. Filter for claims data updated after March 1, 2020 at 3:00 PM Eastern Time by running the following command:
 
 Then run the following command: 
-`python job-cli.py -prod --auth auth-credentials.base64 --directory /opt/foo`
+`python job-cli.py -prod --auth auth-credentials.base64 --directory /opt/foo --since 2020-03-01T15:00:00.000-05:00`
 
 ### Until Parameter
 
@@ -101,8 +102,8 @@ If you only want to pull claims data added to the CMS system before a certain da
 The expected format follows the typical
 ISO date time format of `yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ`.
 
-For requests using FHIR R4, a default `_until` value is supplied if one is not provided. The value of the default `_until`
-parameter is set to the current date and time.
+This parameter is only available with V2 (FHIR R4). 
+If no `_until` date is specified or you use a date from the future, it will default to the current date and time.
 
 Examples:
 1. March 1, 2024 at 3 PM EST -> `2024-03-01T15:00:00.000-05:00`
@@ -123,11 +124,11 @@ Examples:
 
 If you want to:
 1. Start a job running against production
-1. Using base64 encoded credentials stored in `auth-credentials.base64`
-1. And save all results for this job to the directory /opt/foo
+2. Use base64 encoded credentials stored in `auth-credentials.base64`
+3. Save all results for this job to the directory /opt/foo
+4. Filter for claims data updated before March 1, 2024 at 3:00 PM Eastern Time by running the following command:
 
-Then run the following command:
-`python job-cli.py -prod --auth auth-credentials.base64 --directory /opt/foo --until 2020-03-01T15:00:00.000-05:00`
+`python job-cli.py -prod --auth auth-credentials.base64 --directory /opt/foo --until 2024-03-01T15:00:00.000-05:00`
 
 ## Install or verify python 3, pip, and required pip modules
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Examples:
 
 ### Example
 
-If you want to:
 1. Start a job running against production
 2. Use base64 encoded credentials stored in `auth-credentials.base64`
 3. Save all results for this job to the directory /opt/foo
@@ -121,7 +120,6 @@ Examples:
 
 ### Example
 
-If you want to:
 1. Start a job running against production
 2. Use base64 encoded credentials stored in `auth-credentials.base64`
 3. Save all results for this job to the directory /opt/foo

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This script will not overwrite already existing export files.
 
 ```
 Usage: 
-  python job-cli.py (-prod | -sandbox) --auth <authfile.base64> [--directory <dir>] [--since <since>] --fhir (R4 | STU3)
+  python job-cli.py (-prod | -sandbox) --auth <authfile.base64> [--directory <dir>] [--since <since>] [--until <until>] --fhir (R4 | STU3)
         [(--only_start|--only_monitor|--only_download)]
 
 Help (for an explanation of the arguments): 
@@ -49,6 +49,9 @@ Arguments:
   --since         -- if you only want to pull claims data added after a certain date.
                      The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ.
                      Example March 1, 2020 at 3 PM EST -> 2020-03-01T15:00:00.000-05:00. More below.
+  --until         -- if you only want to pull claims data added before a certain date.
+                     The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ.
+                     Example March 1, 2024 at 3 PM EST -> 2024-03-01T15:00:00.000-05:00. More below.
   --fhir          -- FHIR version
 ```
 
@@ -91,6 +94,40 @@ If you want to:
 
 Then run the following command: 
 `python job-cli.py -prod --auth auth-credentials.base64 --directory /opt/foo`
+
+### Until Parameter
+
+If you only want to pull claims data added to the CMS system before a certain date use the `--until` parameter.
+The expected format follows the typical
+ISO date time format of `yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ`.
+
+For requests using FHIR R4, a default `_until` value is supplied if one is not provided. The value of the default `_until`
+parameter is set to the current date and time.
+
+Examples:
+1. March 1, 2024 at 3 PM EST -> `2024-03-01T15:00:00.000-05:00`
+2. May 31, 2024 at 4 AM PST -> `2024-05-31T04:00:00-08:00`
+
+### Files
+
+1. /directory/jobId.txt -- id of the job created
+2. /directory/response.json -- list of files created
+3. /directory/*.ndjson -- downloaded results of exports
+
+### Limitations
+
+1. Assumes all scripts use the same directory
+2. Assumes all scripts use the same base64 encoded AUTH token
+
+### Example
+
+If you want to:
+1. Start a job running against production
+1. Using base64 encoded credentials stored in `auth-credentials.base64`
+1. And save all results for this job to the directory /opt/foo
+
+Then run the following command:
+`python job-cli.py -prod --auth auth-credentials.base64 --directory /opt/foo --until 2020-03-01T15:00:00.000-05:00`
 
 ## Install or verify python 3, pip, and required pip modules
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6110

## 🛠 Changes

Added _until parameter to job-cli.py

## ℹ️ Context

Currently, AB2D API only accepts _since as a date parameter. The goal is for AB2D to be able to support the use case where a PDP could run jobs with time interval based queries so that they could download their data in batches. To achieve that, we will add a _until parameter to define the upper ceiling of the date range.

Both the since and _until parameter will be applied to the lastupdated_Date.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Tested manually on local environment 

<img width="1184" alt="Screenshot 2024-07-26 at 10 29 57 AM" src="https://github.com/user-attachments/assets/efa3ae8b-cce2-40ae-8dcb-91bd40b3aae4">


