### PR TITLE
AB2D-6945 Update sample clients to support v3 API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This may be a great starting point for your engineering or development teams how
 Use of these clients in the sandbox environment allows for safe testing and ensures no PII/PHI will not be compromised 
 if a mistake is made. The sandbox environment is publicly available and all the data in it is synthetic (**not** real)
 
-AB2D supports both R4 and STU3 versions of the FHIR standard. FHIR R4 is available using v2 of AB2D while FHIR STU3 
-can be accessed via AB2D v1. Accordingly, this client supports both R4/ v2 and STU3/ v1.
+AB2D supports both R4 and STU3 versions of the FHIR standard. FHIR R4 is available using v2 and v3 of AB2D while FHIR STU3 
+can be accessed via AB2D v1. Accordingly, this client supports R4/v2, R4/v3 and STU3/v1.
 
 ## Production Use Disclaimer:
 
@@ -24,7 +24,7 @@ Python `requests` module must be installed
 
 A simple client for starting a job in sandbox or production, monitor that job,
 and download the results. To prevent issues these scripts persist the job
-id and list of files generated. This client supports both FHIR version R4 (v2) and STU3 (v1) of 
+id and list of files generated. This client supports FHIR version R4 (v2, v3) and STU3 (v1) of 
 the standard.
 
 This script will not overwrite already existing export files.
@@ -32,7 +32,7 @@ This script will not overwrite already existing export files.
 ```
 Usage: 
   python job-cli.py (-prod | -sandbox) --auth <authfile.base64> [--directory <dir>] [--since <since>] [--until <until>] --fhir (R4 | STU3)
-        [(--only_start|--only_monitor|--only_download)]
+        [(--only_start|--only_monitor|--only_download)] [--ab2d-endpoint (v2 | v3)]
 
 Help (for an explanation of the arguments): 
    python job-cli.py --help
@@ -53,6 +53,7 @@ Arguments:
                      The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ.
                      Example March 1, 2024 at 3 PM EST -> 2024-03-01T15:00:00.000-05:00. More below.
   --fhir          -- FHIR version
+  --ab2d-endpoint -- AB2D API endpoint version when using FHIR R4 (v2 | v3). Defaults to v2 if not specified.
 ```
 
 ### Help

--- a/job-cli.py
+++ b/job-cli.py
@@ -280,8 +280,17 @@ def get_env(args):
     if args.fhir == 'STU3' and args.until is not None:
         raise ValueError("The _until parameter is only available with version 2 (FHIR R4) of the API")
 
-    version_url = "v2"
-    if args.fhir == "STU3":
+    if args.fhir == 'STU3' and args.ab2d_endpoint is not None:
+        raise ValueError("The --ab2d-endpoint parameter is only available with FHIR R4")
+
+    if args.fhir == 'R4':
+        if args.ab2d_endpoint is None:
+            version_url = "v2"
+        else:
+            if args.ab2d_endpoint not in ("v2", "v3"):
+                raise ValueError("When using FHIR R4, --ab2d-endpoint must be one of: v2 or v3")
+            version_url = args.ab2d_endpoint
+    else:
         version_url = "v1"
 
     if args.sandbox:
@@ -348,6 +357,8 @@ parser.add_argument("--only_monitor", action="store_true", help="only monitor an
 parser.add_argument("--only_download", action="store_true", help="only download results from an already finished job"
                                                                  "do not start or monitor")
 parser.add_argument("--fhir", required=True, help="choose FHIR version (R4 or STU3)")
+parser.add_argument("--ab2d-endpoint", dest="ab2d_endpoint",
+                    help="AB2D API endpoint version when using FHIR R4 (v2 or v3). Defaults to v2 if not specified.")
 args = parser.parse_args()
 
 try:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6945

## 🛠 Changes

Added parameter for the AB2D API version.

## ℹ️ Context

Currently the user only provides the --fhir parameter (STU3 or R4).
For the v3 update, we need a new parameter to distinguish between v2 and v3 when the user selects R4.

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
